### PR TITLE
Remove obsolete version from docker compose files

### DIFF
--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
 
   # The IX Database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
 
   # The IX Database


### PR DESCRIPTION
Fixes the following error message:

```
docker-compose.yml: `version` is obsolete
```